### PR TITLE
Fixed typo that broke authentication via HTTP header

### DIFF
--- a/src/TokenAuthentication/TokenSearch.php
+++ b/src/TokenAuthentication/TokenSearch.php
@@ -28,7 +28,7 @@ class TokenSearch
         if (isset($this->options['header'])) {
             if ($request->hasHeader($this->options['header'])) {
                 $header = $request->getHeader($this->options['header'])[0];
-                if (preg_match($this->options['regexp'], $header, $matches)) {
+                if (preg_match($this->options['regex'], $header, $matches)) {
                     return $matches[1];
                 }
             }


### PR DESCRIPTION
There was a small typo in the TokenSearch (regexp instead of regex) that made authentication via HTTP header impossible since the preg_match would never find a match.