### PR TITLE
Allow authenticator to return request with new attributes.

### DIFF
--- a/src/TokenAuthentication.php
+++ b/src/TokenAuthentication.php
@@ -63,11 +63,12 @@ class TokenAuthentication
 
         try {
 
-            if ($this->options['authenticator']($request, $this) === false) {
+            $authenticated_request = $this->options['authenticator']($request, $this);
+            if (!$authenticated_request) {
                 return $this->error($request, $response);
             }
 
-            return $next($request, $response);
+            return $next($authenticated_request, $response);
 
         } catch (UnauthorizedExceptionInterface $e) {
             $this->setResponseMessage($e->getMessage());
@@ -113,7 +114,7 @@ class TokenAuthentication
     {
         /** If exists a custom error function callable, ignore remaining code */
         if (!empty($this->options['error'])) {
-            
+
             $custom_error_response = $this->options['error']($request, $response, $this);
 
             if ($custom_error_response instanceof Response) {


### PR DESCRIPTION
I needed to be able to return `$request->withAttributes('current_user', $user)` from my authenticator. Changes a bit of how the API works though, would require people to update their authenticator code, but provides a lot of much-needed functionality. If I query for my user in my authenticator, there's no reason I should have to perform the same query again in the route.