### PR TITLE
Add support to read token from environment variable

### DIFF
--- a/src/TokenAuthentication.php
+++ b/src/TokenAuthentication.php
@@ -29,7 +29,8 @@ class TokenAuthentication
         'regex' => '/Bearer\s+(.*)$/i',
         'parameter' => 'authorization',
         'cookie' => 'authorization',
-        'argument' => 'authorization'
+        'argument' => 'authorization',
+        'environment' => 'REDIRECT_HTTP_AUTHORIZATION'
     ];
 
     private $response = [];
@@ -142,7 +143,8 @@ class TokenAuthentication
             'regex' => $this->options['regex'],
             'parameter' => $this->options['parameter'],
             'cookie' => $this->options['cookie'],
-            'argument' => $this->options['argument']
+            'argument' => $this->options['argument'],
+            'environment' => $this->options['environment']
         ]);
 
         $token = $tokenSearch($request);

--- a/src/TokenAuthentication/TokenSearch.php
+++ b/src/TokenAuthentication/TokenSearch.php
@@ -34,6 +34,16 @@ class TokenSearch
             }
         }
 
+        /** If using PHP in CGI mode and non standard environment **/
+        $server_params = $request->getServerParams();
+        if (isset($server_params[ $this->options["environment"]])) 
+        {
+            $header = $server_params[ $this->options["environment"]];
+            if (preg_match($this->options['regex'], $header, $matches)) {
+                return $matches[1];
+            }
+        }
+
         /** If nothing on header, try query parameters */
         if (isset($this->options['parameter'])) {
             if (!empty($request->getQueryParams()[$this->options['parameter']]))


### PR DESCRIPTION
Sometimes Apache strips Auth Headers and as workaround we can use rewrite rule to send Auth header to PHP via environment variable as described here: https://stackoverflow.com/questions/26475885/authorization-header-missing-in-php-post-request

To catch auth header from environment I made changes to code, which are working for me.

Not sure about preferable order, but for me it's logical to check it straight after token not found in Headers, but can be easily changed.