### PR TITLE
Add middleware to route or group of routes

### DIFF
--- a/src/TokenAuthentication.php
+++ b/src/TokenAuthentication.php
@@ -19,6 +19,7 @@ use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
+use Slim\Route;
 
 class TokenAuthentication
 {
@@ -94,6 +95,11 @@ class TokenAuthentication
     {
         $uri = $request->getUri()->getPath();
         $uri = '/' . trim($uri, '/');
+
+        /** If middleware applied directly to route or to group of routes we should authenticate */
+        if ($request->getAttribute('route') instanceof Route && $this->options["except"] === null && $this->options["path"] === null) {
+            return true;
+        }
 
         /** If request path is matches except should not authenticate. */
         foreach ((array) $this->options['except'] as $except) {


### PR DESCRIPTION
It's great option for users who wants to add authentication to single route like:
```php
/**
 * Restrict route example
 * Our token is "usertokensecret"
 */
$app->get('/restrict', function($request, $response){
    $output = ['message' => 'It\'s a restrict area. Token authentication works!'];
    return $response->withJson($output, 200, JSON_PRETTY_PRINT);
})->add(new TokenAuthentication([
    'authenticator' => $authenticator,
    'relaxed' => [
        'localhost',
        '127.0.0.1',
        'slim-token-authentication.local'
    ]
]));
```
This way you can change `/restrict` path and not modify middleware settings.
Only `authenticator` option required to restrict access to specified endpoint.

PHPUnit execution output:
```bash
$ composer test
> phpunit
PHPUnit 6.5.13 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.7 with Xdebug 2.6.0
Configuration: C:\wamp64\www\slim-token-authentication\phpunit.xml
...........................................................       59 / 59 (100%)
Time: 490 ms, Memory: 6.00MB
OK (59 tests, 103 assertions)
```